### PR TITLE
feat(icons): add default icon sizes and styles

### DIFF
--- a/layouts/default.hbs
+++ b/layouts/default.hbs
@@ -32,12 +32,12 @@
 <body class="docs-body">
   <div id="docs-topbar" class="docs-topbar no-print">
     <div id="docs-topbar__inner" class="docs-topbar__inner">
-      <a href="#" id="docs-menu-toggle" class="docs-topbar__icon docs-topbar__icon--menu-toggle hidden-desktop"><i class="material-icons md-64">menu</i></a>
-      <a href="#" id="docs-search-hide" class="docs-topbar__icon docs-topbar__icon--search-hide hidden-desktop"><i class="material-icons md-64">arrow_back</i></a>
-      <div class="docs-topbar__icon docs-topbar__icon--search visible-desktop"><i class="material-icons md-64">search</i></div>
+      <a href="#" id="docs-menu-toggle" class="docs-topbar__icon docs-topbar__icon--menu-toggle hidden-desktop"><i class="material-icons md-24">menu</i></a>
+      <a href="#" id="docs-search-hide" class="docs-topbar__icon docs-topbar__icon--search-hide hidden-desktop"><i class="material-icons md-24">arrow_back</i></a>
+      <div class="docs-topbar__icon docs-topbar__icon--search visible-desktop"><i class="material-icons md-24">search</i></div>
       <input id="docs-search-box" type="text" class="docs-topbar__search-box" placeholder="Search" tabindex="1" autocapitalize="none" autocomplete="off" autocorrect="off" autofocus />
-      <a href="#" id="docs-search-close" class="docs-topbar__icon docs-topbar__icon--search-close"><i class="material-icons md-64">close</i></a>
-      <a href="#" id="docs-search-show" class="docs-topbar__icon docs-topbar__icon-search-show hidden-desktop"><i class="material-icons md-64">search</i></a>
+      <a href="#" id="docs-search-close" class="docs-topbar__icon docs-topbar__icon--search-close"><i class="material-icons md-24">close</i></a>
+      <a href="#" id="docs-search-show" class="docs-topbar__icon docs-topbar__icon-search-show hidden-desktop"><i class="material-icons md-24">search</i></a>
 
       {{#each menuLinks}}
           <a class="docs-topbar__link visible-desktop" href="{{ this }}">{{ @key }}</a>

--- a/style/base/_iconography.scss
+++ b/style/base/_iconography.scss
@@ -1,0 +1,15 @@
+// http://google.github.io/material-design-icons/#icon-font-for-the-web
+
+/* Rules for sizing the icon. */
+.material-icons.md-18 { font-size: 18px; }
+.material-icons.md-24 { font-size: 24px; }
+.material-icons.md-36 { font-size: 36px; }
+.material-icons.md-48 { font-size: 48px; }
+
+/* Rules for using icons as black on a light background. */
+.material-icons.md-dark { color: rgba(0, 0, 0, 0.54); }
+.material-icons.md-dark.md-inactive { color: rgba(0, 0, 0, 0.26); }
+
+/* Rules for using icons as white on a dark background. */
+.material-icons.md-light { color: rgba(255, 255, 255, 1); }
+.material-icons.md-light.md-inactive { color: rgba(255, 255, 255, 0.3); }

--- a/style/base/_iconography.scss
+++ b/style/base/_iconography.scss
@@ -7,9 +7,9 @@
 .material-icons.md-48 { font-size: 48px; }
 
 /* Rules for using icons as black on a light background. */
-.material-icons.md-dark { color: rgba(0, 0, 0, 0.54); }
-.material-icons.md-dark.md-inactive { color: rgba(0, 0, 0, 0.26); }
+.material-icons.md-dark { color: rgba(0, 0, 0, .54); }
+.material-icons.md-dark.md-inactive { color: rgba(0, 0, 0, .26); }
 
 /* Rules for using icons as white on a dark background. */
 .material-icons.md-light { color: rgba(255, 255, 255, 1); }
-.material-icons.md-light.md-inactive { color: rgba(255, 255, 255, 0.3); }
+.material-icons.md-light.md-inactive { color: rgba(255, 255, 255, .3); }

--- a/style/base/_iconography.scss
+++ b/style/base/_iconography.scss
@@ -1,15 +1,36 @@
 // http://google.github.io/material-design-icons/#icon-font-for-the-web
 
 /* Rules for sizing the icon. */
-.material-icons.md-18 { font-size: 18px; }
-.material-icons.md-24 { font-size: 24px; }
-.material-icons.md-36 { font-size: 36px; }
-.material-icons.md-48 { font-size: 48px; }
+.material-icons.md-18 {
+  font-size: 18px;
+}
+
+.material-icons.md-24 {
+  font-size: 24px;
+}
+
+.material-icons.md-36 {
+  font-size: 36px;
+}
+
+.material-icons.md-48 {
+  font-size: 48px;
+}
 
 /* Rules for using icons as black on a light background. */
-.material-icons.md-dark { color: rgba(0, 0, 0, .54); }
-.material-icons.md-dark.md-inactive { color: rgba(0, 0, 0, .26); }
+.material-icons.md-dark {
+  color: rgba(0, 0, 0, .54);
+}
+
+.material-icons.md-dark.md-inactive {
+  color: rgba(0, 0, 0, .26);
+}
 
 /* Rules for using icons as white on a dark background. */
-.material-icons.md-light { color: rgba(255, 255, 255, 1); }
-.material-icons.md-light.md-inactive { color: rgba(255, 255, 255, .3); }
+.material-icons.md-light {
+  color: rgba(255, 255, 255, 1);
+}
+
+.material-icons.md-light.md-inactive {
+  color: rgba(255, 255, 255, .3);
+}

--- a/style/base/_module.scss
+++ b/style/base/_module.scss
@@ -1,5 +1,6 @@
 @import "page";
 @import "typography";
+@import "iconography";
 @import "colors";
 @import "img";
 @import "table";


### PR DESCRIPTION
Note, the current `md-64` style does not exist, and if you set the font-size to 64 it looks tremendously oversized. The default (which was used) is 24px.